### PR TITLE
Fixes #2 env variable for postgres password

### DIFF
--- a/complex/k8s/postgres-deployment.yaml
+++ b/complex/k8s/postgres-deployment.yaml
@@ -26,7 +26,7 @@ spec:
               mountPath: /var/lib/postgresql/data
               subPath: postgres
           env:
-            - name: PGPASSWORD
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: pgpassword


### PR DESCRIPTION
As per postgres documentation on docker hub (https://hub.docker.com/r/library/postgres/) 
```
db:
    image: postgres
    restart: always
    environment:
      POSTGRES_PASSWORD: example
```